### PR TITLE
Work around memory leak in `createOpContext`

### DIFF
--- a/core/src/Network/GRPC/LowLevel/Op.hs
+++ b/core/src/Network/GRPC/LowLevel/Op.hs
@@ -56,7 +56,7 @@ data OpContext =
 -- when processing 'OpRecvStatusOnClient'. It appears that gRPC actually ignores
 -- this length and reallocates a longer string if necessary.
 defaultStatusStringLen :: Int
-defaultStatusStringLen = 128
+defaultStatusStringLen = 20
 
 -- | Allocates and initializes the 'Opcontext' corresponding to the given 'Op'.
 createOpContext :: Op -> IO OpContext


### PR DESCRIPTION
* details see: https://github.com/awakesecurity/gRPC-haskell/pull/140/commits/23b114eaf5781f59fe768d0ca0e63d29f6607c6d